### PR TITLE
feat: `baseurl` returns the status of the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ app.use(express.json())
 
 combineRoutes(app)
 
-app.get('/', () => {
+app.get('/', (req, res) => {
     return res.status(200).json({
         message: "Server up and running!"
     })


### PR DESCRIPTION
## Description

The current baseurl, `/` route returns the server status, as up and running

## Related Issue(s)
Fixes #2 

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.


