### PR TITLE
fix: included responder returns on transactions

### DIFF
--- a/src/models/request.js
+++ b/src/models/request.js
@@ -22,6 +22,18 @@ const requestSchema = new mongoose.Schema({
         type: Date,
         default: Date.now
     },
+    from: {
+        type: Date,
+        default: () => new Date()
+    },
+    to: {
+        type: Date,
+        default: () => {
+            const day = new Date()
+            day.setHours(23, 59, 59, 999)
+            return day
+        }
+    },
     status: {
         type: String,
         enum: ["IN_PROCESS", "IN_REVIEW", "ACCEPTED", "REJECTED"],

--- a/src/routes/transaction.routes.js
+++ b/src/routes/transaction.routes.js
@@ -122,7 +122,7 @@ router.get('/history', verifyToken, async (req, res) => {
 
     const transactions = await Transaction.find({
         responder: req._id
-    }).populate('request').populate('origin', '-password')
+    }).populate('request').populate('responder', '-password').populate('origin', '-password')
 
     return res.status(200).json({
         history: transactions


### PR DESCRIPTION
## Description
- The `from` and `to` values were added to the request body, and handled with default values.
- The responder relation is returned back with their document details on transaction history requests.

## Related Issue(s)
Fixes #19 

## Testing
LOCAL Testing using POSTMAN was done.

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.

## Additional Notes
- Data is too large, and sometimes unnecessary, according to the issue. need to be worked on with further issues.

