### PR TITLE
feat(cleanup): cleaned up object returns over `transaction/history`

### DIFF
--- a/src/routes/transaction.routes.js
+++ b/src/routes/transaction.routes.js
@@ -122,7 +122,10 @@ router.get('/history', verifyToken, async (req, res) => {
 
     const transactions = await Transaction.find({
         responder: req._id
-    }).populate('request').populate('responder', '-password').populate('origin', '-password')
+    })
+    .populate('request', 'subject message from to status -_id')
+    .populate('responder', 'name -_id')
+    .populate('origin', 'name -_id')
 
     return res.status(200).json({
         history: transactions


### PR DESCRIPTION
## Description
- The return over the GET Request for `transaction/history` gives the following structure.
<img width="966" alt="image" src="https://github.com/niyasrad/CelestiDesk-BE/assets/84234554/786627d4-18f2-4db5-9ea4-f9c044141f56">


## Related Issue(s)
Fixes #21 

## Testing
Local Testing was performed over POSTMAN

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.
