### PR TITLE
feat(expiry, emergency): enabled expiry, emergency flair

### DIFF
--- a/src/models/employee.js
+++ b/src/models/employee.js
@@ -16,7 +16,7 @@ const employeeSchema = mongoose.Schema({
     },
     type: {
         type: String,
-        enum: ['EMPLOYEE', 'TEAM_LEAD', 'MANAGER'],
+        enum: ['EMPLOYEE', 'TEAM_LEAD', 'MANAGER', 'EMERGENCY'],
         required: true
     },
     password: {

--- a/src/models/request.js
+++ b/src/models/request.js
@@ -34,6 +34,10 @@ const requestSchema = new mongoose.Schema({
             return day
         }
     },
+    emergency: {
+        type: Boolean,
+        default: false
+    },
     status: {
         type: String,
         enum: ["IN_PROCESS", "IN_REVIEW", "ACCEPTED", "REJECTED"],

--- a/src/routes/employee.routes.js
+++ b/src/routes/employee.routes.js
@@ -12,7 +12,7 @@ router.post('/signup', async (req, res) => {
         })
     }
 
-    if (!['EMPLOYEE', 'TEAM_LEAD', 'MANAGER'].includes(req.body.type)) {
+    if (!['EMPLOYEE', 'TEAM_LEAD', 'MANAGER', 'EMERGENCY'].includes(req.body.type)) {
         return res.status(400).json({
             message: "Please check your type!"
         })

--- a/src/routes/request.routes.js
+++ b/src/routes/request.routes.js
@@ -30,6 +30,7 @@ router.post('/create', verifyToken, async (req, res) => {
             origin: req._id,
             subject: req.body.subject,
             message: req.body.message,
+            emergency: req.body.emergency ? true: false,
             requestdate: new Date(req.body.date),
         })
     
@@ -68,9 +69,17 @@ router.get('/pending', verifyToken, async (req, res) => {
 
     let statusAccepted = user.type === 'MANAGER' ? 'IN_REVIEW' : 'IN_PROCESS'
 
-    let pendingRequests = await Request.find({
+    let query = {
         status: statusAccepted
-    })
+    }
+    
+    let emergencyNeeded = user.type === 'EMERGENCY'
+
+    if (emergencyNeeded) {
+        query.emergency = true;
+    }
+
+    let pendingRequests = await Request.find(query)
 
     return res.status(200).json({
         requests: pendingRequests

--- a/src/routes/transaction.routes.js
+++ b/src/routes/transaction.routes.js
@@ -70,10 +70,11 @@ router.post('/decide', verifyToken, async (req, res) => {
         })
     }
 
-    if (request.status === 'IN_PROCESS' && user.type === 'TEAM_LEAD') {
+    if (request.status === 'IN_PROCESS' && (user.type === 'TEAM_LEAD' || user.type === 'EMERGENCY')) {
 
         if (req.body.decision === 'ACCEPTED') {
             request.status = 'IN_REVIEW'
+            request.time = Date.now()
         } else {
             request.status = 'REJECTED'
         }
@@ -81,6 +82,14 @@ router.post('/decide', verifyToken, async (req, res) => {
         
     } else if (request.status === 'IN_REVIEW' && user.type === 'MANAGER') {
 
+        if (Date.now() > request.time.getTime() + 20 * 60 * 1000 && !request.emergency) {
+            
+            return res.status(400).json({
+                message: "Request Timed Out!"
+            })
+
+        }
+        
         if (req.body.decision === 'ACCEPTED') {
             request.status = 'ACCEPTED'
         } else {


### PR DESCRIPTION
## Description
- Added `emergency` flair over requests, and they don't have an expiry rate.
- Added an expiry check over requests for the manager to check when it's over 20 minutes of `TEAM_LEAD` approval.

## Related Issue(s)
Fixes #23
Fixes #24 

## Testing
- Did local testing on POSTMAN.

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.


