### PR TITLE
fix(emergency): removed allowance cap on emergency requests

### DIFF
--- a/src/routes/request.routes.js
+++ b/src/routes/request.routes.js
@@ -13,12 +13,13 @@ router.post('/create', verifyToken, async (req, res) => {
 
     const recentRequests = await Request.countDocuments({
         origin: req._id,
+        emergency: false,
         time: {
             $gte: Date.now() - (30 * 24 * 60 * 60 * 1000)
         }
     })
 
-    if (recentRequests >= 5) {
+    if (!req.body.emergency && recentRequests >= 5) {
         return res.status(400).json({
             message: "You've used up 5 requests this month!"
         })


### PR DESCRIPTION
## Description
- The `5 request/month` cap  on the requests has been disregarded for emergency requests.
- Following that, the check of the **number of requests** of the user has been modified to **not taking emergency requests** into count. 
- Which means, users can build on emergency requests without worry of having reached the request cap.

## Related Issue(s)
Fixes #32 

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.


