### PR TITLE
fix(name): returns name instead of document id

### DIFF
--- a/src/routes/request.routes.js
+++ b/src/routes/request.routes.js
@@ -74,7 +74,7 @@ router.get('/pending', verifyToken, async (req, res) => {
 
         let pendingRequests = await Request.find({
             origin: user._id
-        })
+        }).populate('origin', 'name -_id')
 
         return res.status(200).json({
             requests: pendingRequests
@@ -98,7 +98,7 @@ router.get('/pending', verifyToken, async (req, res) => {
         }
     }
 
-    let pendingRequests = await Request.find(query)
+    let pendingRequests = await Request.find(query).populate('origin', 'name -_id')
 
     return res.status(200).json({
         requests: pendingRequests


### PR DESCRIPTION
## Description
- The `/pending` requests have been modified to populate the `name` instead of `_id` tag.
- This will enable for displaying of names over the pending/other requests in the mobile app.

## Related Issue(s)
Fixes #34 

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.